### PR TITLE
fix completion for tome names with 2+ chars

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -34,5 +34,5 @@ pub fn help(root: &str) -> Result<String, String> {
 // escape slash characters with posix-compatible quotes. Helps if the echo
 // command uses slashes
 fn escape_slashes(s: &str) -> String {
-    s.replace("'", "'\\''")
+    s.replace('\'', "'\\''")
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -72,7 +72,7 @@ function {function_name} {{
 function _{function_name}_completions {{
     local token_to_complete tome_args
     token_to_complete="${{COMP_WORDS[COMP_CWORD]}}";
-    tome_args=${{COMP_LINE:2}};  # strip the first argument prefix, which is the function name
+    tome_args=${{COMP_WORDS[@]:1}};  # strip the first argument prefix, which is the function name
     # strip the partial token_to_complete, if there is one
     tome_args=${{tome_args%$token_to_complete}};
     all_options=`{tome_executable} command-complete {script_root} -- $tome_args`

--- a/src/script.rs
+++ b/src/script.rs
@@ -141,7 +141,7 @@ impl Script {
                 // interpret character sequences.
                 let mut escaped_command_string = vec![];
                 for mut arg in command_string {
-                    arg = arg.replace("'", "\\'");
+                    arg = arg.replace('\'', "\\'");
                     arg.insert(0, '\'');
                     arg.push('\'');
                     escaped_command_string.push(arg);


### PR DESCRIPTION
fix #28 (GitHub)

tome completion was failing for a command "app", when
navigating to sub directories.

This was occurring due to incorrect stripping of
the first word in completion, instead stripping the
first 2 chars.