### PR TITLE
Require "COMPLETION" flag to complete script

### DIFF
--- a/docs/authoring-scripts.md
+++ b/docs/authoring-scripts.md
@@ -12,7 +12,14 @@ This page covers some more advanced scenarios.
 
 ## Tab Completion by Script
 
-Tab completion for a script can improve the usability significantly. When tab-completion is requested for a specific script, the script is invoked with the "--complete" argument passed at the end.
+Tab completion for a script can improve the usability significantly. Tab completion can be turned on for a script by including a comment with the string "COMPLETION" in the top of the script:
+
+```
+#!/usr/bin/env python
+# COMPLETION
+```
+
+When tab-completion is requested for a specific script, the script is invoked with the "--complete" argument passed at the end.
 
 For example, in the example, tab-completing the following:
 

--- a/example/file_example
+++ b/example/file_example
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # SUMMARY: hey'
+# COMPLETION
 # START HELP
 # this is an example of a simple script written in python.
 # END HELP

--- a/example/source_example
+++ b/example/source_example
@@ -1,4 +1,5 @@
 # SOURCE
+# COMPLETION
 # SUMMARY: an example for sourcing variables
 # START HELP
 # This is an example of a script that is sourced, rather

--- a/example/test_files/file_example_no_completion
+++ b/example/test_files/file_example_no_completion
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# SUMMARY: hey'
+# START HELP
+# this is an example of a simple script written in python.
+# but does not support completion, so tome should not
+# try to invoke completion
+# END HELP
+import sys
+
+print("hello")

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -14,7 +14,7 @@ export SHELL
 cargo build --release
 # init the tome in question
 # $SHELL doesn't work in this context, albeit preferable,
-# as it's not available during GitHub workflow runs.
+# as it's not available during GitHub workf>low runs.
 eval "$(./target/release/tome init e ./example $SHELL)"
 
 # regular script example

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -88,6 +88,24 @@ fn test_simple_script_completion() {
     );
 }
 
+/// Unless the file has the completion annotation
+/// do not invoked completion on it and return nothing
+/// instead.
+#[test]
+fn test_simple_script_no_completion() {
+    assert_eq!(
+        execute(_vec_str(vec![
+            "tome",
+            "command-complete",
+            EXAMPLE_DIR,
+            "--",
+            "test_files",
+            "file_example_no_completion",
+        ])),
+        Ok(String::from(""))
+    );
+}
+
 /// basic test for a script that should be sourced
 #[test]
 fn test_source() {
@@ -145,7 +163,7 @@ fn test_root_directory_completion() {
     assert_eq!(
         execute(_vec_str(vec!["tome", "command-complete", EXAMPLE_DIR])),
         // note that we also complete with builtins
-        Ok("commands dir_example exec file_example help practical_examples source_example source_example_fish tome use-arg".to_string())
+        Ok("commands dir_example exec file_example help practical_examples source_example source_example_fish test_files tome use-arg".to_string())
     );
 }
 
@@ -287,8 +305,8 @@ fn test_help_page_when_execute_no_args() {
 fn assert_is_help_text(result: &str) {
     // uncomment to see output
     // println!("{}", result);
-    assert_eq!(result.matches("'\\''").count(), 1);
-    assert_eq!(result.matches("'").count(), 5);
+    assert_eq!(result.matches("'\\''").count(), 2);
+    assert_eq!(result.matches("'").count(), 8);
     assert!(result.contains("echo -e"));
     // verify that builtin tome commands are present
     assert!(result.contains("commands:"));


### PR DESCRIPTION
tome by default attempted to get completion for a script by executing
it.

As the default behavior, this can be error-prone: the user may not
want their script to execute because it can cause destructive behavior,
and that could be executed with a tab button pressed via muscle memory.

If completion is supported, require the user to explicitly state as
such instead.

fixes #29 