### PR TITLE
require shell to be passed in

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -15,7 +15,7 @@ cargo build --release
 # init the tome in question
 # $SHELL doesn't work in this context, albeit preferable,
 # as it's not available during GitHub workf>low runs.
-eval "$(./target/release/tome init e ./example $SHELL)"
+eval "$(./target/release/tome init e ./example "$SHELL")"
 
 # regular script example
 GOT=$(e file_example)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,9 @@ pub enum TomeCommands {
 #[derive(Debug, Args)]
 pub struct CompleteArgs {
     pub command_directory_path: String,
+    /// The type of the shell that is invoking completion
+    #[clap(short, long)]
+    pub shell: String,
     #[clap(last = true)]
     pub args: Vec<String>,
 }
@@ -28,6 +31,8 @@ pub struct CompleteArgs {
 #[derive(Debug, Args)]
 pub struct ExecuteArgs {
     pub command_directory_path: String,
+    #[clap(short, long)]
+    pub shell: String,
     #[clap(last = true)]
     pub args: Vec<String>,
 }
@@ -44,6 +49,5 @@ pub struct InitArgs {
     /// The path to the directory that contains the commands to load.
     pub command_directory_path: String,
     /// The type of the shell to use, or the path to the shell executable being used.
-    /// If this is none, the SHELL environment variable will be used.
-    pub shell_type_or_path: Option<String>,
+    pub shell_type_or_path: String,
 }

--- a/src/commands/builtins.rs
+++ b/src/commands/builtins.rs
@@ -2,7 +2,7 @@ use super::{execute::execute, help::help};
 use std::collections::HashMap;
 
 pub struct Command {
-    pub func: fn(&str, &[String]) -> Result<String, String>,
+    pub func: fn(&str, &str, &[String]) -> Result<String, String>,
     pub help_text: &'static str,
 }
 
@@ -12,28 +12,28 @@ lazy_static! {
         m.insert(
             "commands".to_owned(),
             Command {
-                func: help_command as fn(&str, &[String]) -> Result<String, String>,
+                func: help_command as fn(&str, &str, &[String]) -> Result<String, String>,
                 help_text: "print all commands",
             },
         );
         m.insert(
             "exec".to_owned(),
             Command {
-                func: exec_command as fn(&str, &[String]) -> Result<String, String>,
+                func: exec_command as fn(&str, &str, &[String]) -> Result<String, String>,
                 help_text: "execute a command",
             },
         );
         m.insert(
             "help".to_owned(),
             Command {
-                func: help_command as fn(&str, &[String]) -> Result<String, String>,
+                func: help_command as fn(&str, &str, &[String]) -> Result<String, String>,
                 help_text: "print help for the command",
             },
         );
         m.insert(
             "tome".to_owned(),
             Command {
-                func: noop_command as fn(&str, &[String]) -> Result<String, String>,
+                func: noop_command as fn(&str, &str, &[String]) -> Result<String, String>,
                 help_text: "currently a no-op. reserved namespace for future tome commands",
             },
         );
@@ -41,15 +41,15 @@ lazy_static! {
     };
 }
 
-fn exec_command(root: &str, args: &[String]) -> Result<String, String> {
+fn exec_command(root: &str, shell: &str, args: &[String]) -> Result<String, String> {
     // strip the first argument since it should be "exec"
-    execute(root, &args[1..])
+    execute(root, shell, &args[1..])
 }
 
-fn help_command(root: &str, _: &[String]) -> Result<String, String> {
+fn help_command(root: &str, _: &str, _: &[String]) -> Result<String, String> {
     help(root)
 }
 
-fn noop_command(_: &str, _: &[String]) -> Result<String, String> {
+fn noop_command(_: &str, _: &str, _: &[String]) -> Result<String, String> {
     Ok("".to_owned())
 }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -5,7 +5,11 @@ use super::super::{
 use super::{builtins::BUILTIN_COMMANDS, help};
 use std::path::PathBuf;
 
-pub fn execute(command_directory_path: &str, args: &[String]) -> Result<String, String> {
+pub fn execute(
+    command_directory_path: &str,
+    shell: &str,
+    args: &[String],
+) -> Result<String, String> {
     // next, we determine if we have a file or a directory,
     // recursing down arguments until we've exhausted arguments
     // that match a directory or file.
@@ -20,7 +24,7 @@ pub fn execute(command_directory_path: &str, args: &[String]) -> Result<String, 
     // commands
     match args_peekable.peek() {
         Some(&command_name) => match BUILTIN_COMMANDS.get(command_name) {
-            Some(command) => return (command.func)(command_directory_path, args),
+            Some(command) => return (command.func)(command_directory_path, shell, args),
             None => {}
         },
         None => {}
@@ -57,7 +61,7 @@ pub fn execute(command_directory_path: &str, args: &[String]) -> Result<String, 
             )),
         },
         TargetType::File => match script::Script::load(target.to_str().unwrap_or_default()) {
-            Ok(script) => script.get_execution_body(CommandType::Execute, &remaining_args),
+            Ok(script) => script.get_execution_body(CommandType::Execute, &shell, &remaining_args),
             Err(error) => return Err(format!("IOError loading file: {:?}", error)),
         },
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,14 @@ pub fn execute(raw_args: Vec<String>) -> Result<String, String> {
         Ok(tome_args) => match &tome_args.commands {
             cli::TomeCommands::CommandComplete(complete_args) => commands::complete::complete(
                 &complete_args.command_directory_path,
+                &complete_args.shell,
                 &complete_args.args,
             ),
-            cli::TomeCommands::CommandExecute(execute_args) => {
-                commands::execute::execute(&execute_args.command_directory_path, &execute_args.args)
-            }
+            cli::TomeCommands::CommandExecute(execute_args) => commands::execute::execute(
+                &execute_args.command_directory_path,
+                &execute_args.shell,
+                &execute_args.args,
+            ),
             cli::TomeCommands::CommandHelp(help_args) => {
                 commands::help::help(&help_args.command_directory_path)
             }

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -1,7 +1,7 @@
 use super::execute;
-use std::env;
 
 const EXAMPLE_DIR: &'static str = "./example";
+const SHELL: &'static str = "bash";
 
 fn _vec_str(args: Vec<&str>) -> Vec<String> {
     args.iter().map(|s| s.to_string()).collect()
@@ -15,6 +15,8 @@ fn test_exec_simple_script() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "exec",
@@ -32,6 +34,8 @@ fn test_exec_recursive_simple_script() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "exec",
@@ -50,6 +54,8 @@ fn test_simple_script() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "file_example"
@@ -65,6 +71,8 @@ fn test_simple_script_with_args() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "file_example",
@@ -80,6 +88,8 @@ fn test_simple_script_completion() {
         execute(_vec_str(vec![
             "tome",
             "command-complete",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "file_example",
@@ -97,6 +107,8 @@ fn test_simple_script_no_completion() {
         execute(_vec_str(vec![
             "tome",
             "command-complete",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "test_files",
@@ -113,6 +125,8 @@ fn test_source() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            SHELL,
             EXAMPLE_DIR,
             "--",
             "source_example",
@@ -123,16 +137,12 @@ fn test_source() {
 
 #[test]
 fn test_source_completion() {
-    // Context: https://github.com/toumorokoshi/tome/issues/6
-    // Override SHELL env variable due to test depending on sourced file
-    // being a bash/zsh compatible sourced file.
-    // The behavior of sourcing scripts works in cli and we patch
-    // in tests to ensure consistent results.
-    env::set_var("SHELL", "bash");
     assert_eq!(
         execute(_vec_str(vec![
             "tome",
             "command-complete",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "source_example",
@@ -149,6 +159,8 @@ fn test_directory_completion() {
         execute(_vec_str(vec![
             "tome",
             "command-complete",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "dir_example",
@@ -161,9 +173,27 @@ fn test_directory_completion() {
 #[test]
 fn test_root_directory_completion() {
     assert_eq!(
-        execute(_vec_str(vec!["tome", "command-complete", EXAMPLE_DIR])),
+        execute(_vec_str(vec!["tome", "command-complete", "-s", "bash", EXAMPLE_DIR])),
         // note that we also complete with builtins
         Ok("commands dir_example exec file_example help practical_examples source_example source_example_fish test_files tome use-arg".to_string())
+    );
+}
+
+/// the tome command is a no-op, and shouldn't
+/// have completion
+#[test]
+fn test_tome_completion() {
+    assert_eq!(
+        execute(_vec_str(vec![
+            "tome",
+            "command-complete",
+            "-s",
+            SHELL,
+            EXAMPLE_DIR,
+            "--",
+            "tome",
+        ])),
+        Ok(String::from(""))
     );
 }
 
@@ -175,6 +205,8 @@ fn test_script_in_directory() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "dir_example",
@@ -192,6 +224,8 @@ fn test_script_in_directory_not_found() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "dir_example",
@@ -212,6 +246,8 @@ fn test_script_directory_argument() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "dir_example",
@@ -232,6 +268,8 @@ fn test_use_arg() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "use-arg"
@@ -248,6 +286,8 @@ fn test_dangerous_characters_quoted() {
         execute(_vec_str(vec![
             "tome",
             "command-execute",
+            "-s",
+            "bash",
             EXAMPLE_DIR,
             "--",
             "use-arg"
@@ -263,6 +303,8 @@ fn test_execute_help() {
     let result = execute(_vec_str(vec![
         "tome",
         "command-execute",
+        "-s",
+        "bash",
         EXAMPLE_DIR,
         "--",
         "help",
@@ -278,6 +320,8 @@ fn test_execute_commands() {
     let result = execute(_vec_str(vec![
         "tome",
         "command-execute",
+        "-s",
+        "bash",
         EXAMPLE_DIR,
         "--",
         "commands",
@@ -296,7 +340,15 @@ fn test_help_page() {
 /// help should be returned if no arguments are passed.
 #[test]
 fn test_help_page_when_execute_no_args() {
-    let result = execute(_vec_str(vec!["tome", "command-execute", EXAMPLE_DIR, "--"])).unwrap();
+    let result = execute(_vec_str(vec![
+        "tome",
+        "command-execute",
+        "-s",
+        "bash",
+        EXAMPLE_DIR,
+        "--",
+    ]))
+    .unwrap();
     assert_is_help_text(&result)
 }
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -5,7 +5,6 @@ pub fn is_tome_script(filename: &str) -> bool {
 
 use super::types::CommandType;
 use std::{
-    env::var,
     fs::File,
     io,
     io::{prelude::*, BufReader, Read},
@@ -93,6 +92,7 @@ impl Script {
     pub fn get_execution_body(
         &self,
         command_type: CommandType,
+        shell: &str,
         args: &[&String],
     ) -> Result<String, String> {
         match command_type {
@@ -104,7 +104,7 @@ impl Script {
                 // There's a possible optimization here
                 // if we just inherit parent file descriptors.
                 let mut command = match self.should_source {
-                    true => Command::new(var("SHELL").unwrap_or_default()),
+                    true => Command::new(shell),
                     false => Command::new(self.path.clone()),
                 };
                 if self.should_source {


### PR DESCRIPTION
*BREAKING CHANGE*

shell inference via the SHELL environment variable can be unreliable:

- not all distros or shells use that convention, such as fish.
- this doesn't successfully indicate the sub-shell being used.

As such, it's usage should be removed.

Also fixing a bug with completion for builtin commands