### PR TITLE
feat: Add `tome run`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-clap = { version = "3.0.7", features = ["derive"]}
+clap = { version = "3.0.7", features = ["derive"] }
 lazy_static = { version = "1.4.0" }
-
 
 
 [dev-dependencies]

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -40,3 +40,11 @@ WANT="bar"
 if [ "${GOT}" != "${WANT}" ]; then
     echo "regular nested script failed; Got '${GOT}', want '${WANT}'"
 fi
+
+# test `tome run`, which cannot be tested in a
+# regular test due to it's usage of exec.
+GOT=$(./target/release/tome run ./example -- dir_example bar)
+WANT="bar"
+if [ "${GOT}" != "${WANT}" ]; then
+    echo "tome run nested script failed; Got '${GOT}', want '${WANT}'"
+fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,11 @@ pub enum TomeCommands {
     CommandComplete(CompleteArgs),
     CommandExecute(ExecuteArgs),
     Init(InitArgs),
+    /// find a script and exec it.
+    /// run will not run the script in completion mode,
+    /// regardless of the script front matter. builtins such as
+    /// help are not accessible via this command
+    Run(RunArgs),
 }
 
 #[derive(Debug, Args)]
@@ -50,4 +55,11 @@ pub struct InitArgs {
     pub command_directory_path: String,
     /// The type of the shell to use, or the path to the shell executable being used.
     pub shell_type_or_path: String,
+}
+
+#[derive(Debug, Args)]
+pub struct RunArgs {
+    pub command_directory_path: String,
+    #[clap(last = true)]
+    pub args: Vec<String>,
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -19,7 +19,7 @@ pub fn complete(
     let mut args_peekable = args.iter().peekable();
     // handle if the first command is a builtin
     if let Some(subcommand) = args_peekable.peek() {
-        if let Some(_) = BUILTIN_COMMANDS.get(*subcommand) {
+        if BUILTIN_COMMANDS.get(*subcommand).is_some() {
             return Ok(String::new());
         }
     }
@@ -77,7 +77,7 @@ pub fn complete(
         }
         TargetType::File => match script::Script::load(target.to_str().unwrap_or_default()) {
             Ok(script) => {
-                script.get_execution_body(CommandType::Completion, &shell, &remaining_args)
+                script.get_execution_body(CommandType::Completion, shell, &remaining_args)
             }
             Err(error) => return Err(format!("IOError loading file: {:?}", error)),
         },

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -1,9 +1,5 @@
-use super::super::{
-    script,
-    types::{CommandType, TargetType},
-};
+use super::super::{finder, script, types::CommandType};
 use super::{builtins::BUILTIN_COMMANDS, help};
-use std::path::PathBuf;
 
 pub fn execute(
     command_directory_path: &str,
@@ -13,8 +9,6 @@ pub fn execute(
     // next, we determine if we have a file or a directory,
     // recursing down arguments until we've exhausted arguments
     // that match a directory or file.
-    let mut target = PathBuf::from(&command_directory_path);
-    let mut target_type = TargetType::Directory;
     let mut args_peekable = args.iter().peekable();
     // if no argument is passed, return help.
     if args_peekable.peek().is_none() {
@@ -30,39 +24,15 @@ pub fn execute(
         None => {}
     }
     // generic handling
-    while let Some(arg) = args_peekable.peek() {
-        target.push(arg);
-        if target.is_file() {
-            target_type = TargetType::File;
-            args_peekable.next();
-            break;
-        } else if target.is_dir() {
-            target_type = TargetType::Directory;
-            args_peekable.next();
-        } else {
-            // the current argument does not match
-            // a directory or a file, so we've landed
-            // on the strictest match.
-            target.pop();
-            break;
+    match finder::find_script(command_directory_path, args) {
+        Ok(script_invocation) => {
+            match script::Script::load(script_invocation.target.to_str().unwrap_or_default()) {
+                Ok(script) => {
+                    script.get_execution_body(CommandType::Execute, &shell, &script_invocation.args)
+                }
+                Err(error) => return Err(format!("IOError loading file: {:?}", error)),
+            }
         }
+        Err(err) => Err(err),
     }
-    let remaining_args: Vec<_> = args_peekable.collect();
-    return match target_type {
-        TargetType::Directory => match remaining_args.len() {
-            0 => Err(format!(
-                "{} is a directory. tab-complete to choose subcommands",
-                target.to_str().unwrap_or("")
-            )),
-            _ => Err(format!(
-                "command {} not found in directory {}",
-                remaining_args[0],
-                target.to_str().unwrap_or("")
-            )),
-        },
-        TargetType::File => match script::Script::load(target.to_str().unwrap_or_default()) {
-            Ok(script) => script.get_execution_body(CommandType::Execute, &shell, &remaining_args),
-            Err(error) => return Err(format!("IOError loading file: {:?}", error)),
-        },
-    };
 }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -16,21 +16,19 @@ pub fn execute(
     }
     // special handling for root subcommmand for reserved
     // commands
-    match args_peekable.peek() {
-        Some(&command_name) => match BUILTIN_COMMANDS.get(command_name) {
-            Some(command) => return (command.func)(command_directory_path, shell, args),
-            None => {}
-        },
-        None => {}
+    if let Some(&command_name) = args_peekable.peek() {
+        if let Some(command) = BUILTIN_COMMANDS.get(command_name) {
+            return (command.func)(command_directory_path, shell, args);
+        }
     }
     // generic handling
     match finder::find_script(command_directory_path, args) {
         Ok(script_invocation) => {
             match script::Script::load(script_invocation.target.to_str().unwrap_or_default()) {
                 Ok(script) => {
-                    script.get_execution_body(CommandType::Execute, &shell, &script_invocation.args)
+                    script.get_execution_body(CommandType::Execute, shell, &script_invocation.args)
                 }
-                Err(error) => return Err(format!("IOError loading file: {:?}", error)),
+                Err(error) => Err(format!("IOError loading file: {:?}", error)),
             }
         }
         Err(err) => Err(err),

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -20,8 +20,8 @@ pub fn help(root: &str) -> Result<String, String> {
     for (command, command_struct) in BUILTIN_COMMANDS.iter() {
         builtins_with_help.push(format!(
             "    {}: {}",
-            escape_slashes(&command),
-            escape_slashes(&command_struct.help_text),
+            escape_slashes(command),
+            escape_slashes(command_struct.help_text),
         ))
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod complete;
 pub mod execute;
 pub mod help;
 pub mod init;
+pub mod run;
 #[cfg(test)]
 mod tests;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,17 @@
+use super::super::finder;
+use std::os::unix::process::CommandExt;
+
+pub fn run(command_directory_path: &str, args: &[String]) -> Result<String, String> {
+    // generic handling
+    match finder::find_script(command_directory_path, args) {
+        // although both paths will always error, the Ok() path actually will
+        // likely complete as expected, as an exec effectively transforms the
+        // existing process into the new command, which may complete
+        // successfully.
+        Ok(script_invocation) => Err(std::process::Command::new(script_invocation.target)
+            .args(script_invocation.args)
+            .exec()
+            .to_string()),
+        Err(err) => Err(err),
+    }
+}

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -1,0 +1,57 @@
+use super::types::TargetType;
+use std::path::PathBuf;
+
+pub struct ScriptInvocation<'a> {
+    /// The script that that is being invoked.
+    pub target: PathBuf,
+    /// The arguments that should be passed directly to the script.
+    pub args: Vec<&'a String>,
+}
+
+pub fn find_script<'a>(
+    command_directory_path: &str,
+    args: &'a [String],
+) -> Result<ScriptInvocation<'a>, String> {
+    // next, we determine if we have a file or a directory,
+    // recursing down arguments until we've exhausted arguments
+    // that match a directory or file.
+    let mut target = PathBuf::from(&command_directory_path);
+    let mut target_type = TargetType::Directory;
+    let mut args_peekable = args.iter().peekable();
+    // generic handling
+    while let Some(arg) = args_peekable.peek() {
+        target.push(arg);
+        if target.is_file() {
+            target_type = TargetType::File;
+            args_peekable.next();
+            break;
+        } else if target.is_dir() {
+            target_type = TargetType::Directory;
+            args_peekable.next();
+        } else {
+            // the current argument does not match
+            // a directory or a file, so we've landed
+            // on the strictest match.
+            target.pop();
+            break;
+        }
+    }
+    let remaining_args: Vec<_> = args_peekable.collect();
+    return match target_type {
+        TargetType::Directory => match remaining_args.len() {
+            0 => Err(format!(
+                "{} is a directory. tab-complete to choose subcommands",
+                target.to_str().unwrap_or("")
+            )),
+            _ => Err(format!(
+                "command {} not found in directory {}",
+                remaining_args[0],
+                target.to_str().unwrap_or("")
+            )),
+        },
+        TargetType::File => Ok(ScriptInvocation {
+            target,
+            args: remaining_args,
+        }),
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate lazy_static;
 pub mod cli;
 pub mod commands;
 pub mod directory;
+pub mod finder;
 pub mod script;
 pub mod shell_type;
 pub mod types;
@@ -39,6 +40,9 @@ pub fn execute(raw_args: Vec<String>) -> Result<String, String> {
                 commands::help::help(&help_args.command_directory_path)
             }
             cli::TomeCommands::Init(init_args) => commands::init::init(&tome_executable, init_args),
+            cli::TomeCommands::Run(run_args) => {
+                commands::run::run(&run_args.command_directory_path, &run_args.args)
+            }
         },
         Err(msg) => Err(msg.to_string()),
     }

--- a/src/script.rs
+++ b/src/script.rs
@@ -79,11 +79,11 @@ impl Script {
             }
         }
         Script {
-            help_string: help_string,
-            path: path,
-            should_complete: should_complete,
-            should_source: should_source,
-            summary_string: summary_string,
+            help_string,
+            path,
+            should_complete,
+            should_source,
+            summary_string,
         }
     }
 


### PR DESCRIPTION
tome run satisfies a use case where one would like to re-use tome's script navigation functionality, but in an environment that is not an interactive shell.

This could be useful in a situation where one would like to share scripts across a local and deployed envioronment.

tome run does an execve to effectively become the function invoked: although this is less cross-platform compatible, it results in the simplest method to reduce complications like buffer sizes handing off data in intermediary pipes.

refactoring some finder logic out for re-use.

fixes #40.