### PR TITLE
chore: update osx ci testA

### DIFF
--- a/.github/workflows/osx-build.yml
+++ b/.github/workflows/osx-build.yml
@@ -2,7 +2,7 @@ on: [push]
 name: build-osx
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
macos-10.15 is no longer available on public
GitHub runners.