### PR TITLE
fix: fix completion for sh/bash/zsh

### DIFF
--- a/example/dir_example/baz
+++ b/example/dir_example/baz
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# COMPLETE
+# showing a case of returnin deeper completes
+if [[ "$1" == "--complete" ]]; then
+    echo "--bar1 --bar2 --not-bar"
+    exit
+fi
+echo "COMMAND: baz $*"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -45,7 +45,7 @@ function _{function_name}_completions {{
     # strip the partial token_to_complete, if there is one
     tome_args=${{tome_args%$token_to_complete}};
     all_options=`{tome_executable} command-complete {script_root} -s {shell} -- $tome_args`
-    valid_options=$(compgen -W "$all_options" "$token_to_complete")
+    valid_options=$(compgen -W "$all_options" -- "$token_to_complete")
     COMPREPLY=($valid_options)
 }}
 

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -165,7 +165,7 @@ fn test_directory_completion() {
             "--",
             "dir_example",
         ])),
-        Ok("bar foo".to_string())
+        Ok("bar baz foo".to_string())
     );
 }
 


### PR DESCRIPTION
issue #43 reported compgen failing on completion parameters that looked like they were command line switches (e.g. "--")

This looks to be due to incorrect usage of compgen, where the difference between options and the user's completion  to complete were not separated with the "--" delimiter. According to getopt(1) documentation this should be split explicitly:

       When the end of options is encountered, the getopts utility shall
       exit with a return value greater than zero; the shell variable
       OPTIND shall be set to the index of the first operand, or the
       value "$#"+1 if there are no operands; the name variable shall be
       set to the <question-mark> character. Any of the following shall
       identify the end of options: the first "--" argument that is not
       an option-argument, finding an argument that is not an option-
       argument and does not begin with a '-', or encountering an error.

This fixes the issue when reproing locally.